### PR TITLE
Fixed issue where the collection being edited could be added to the collection!

### DIFF
--- a/app/containers/ChooseCollectionCard/View.tsx
+++ b/app/containers/ChooseCollectionCard/View.tsx
@@ -35,29 +35,31 @@ const CollectionsContent = ({
 }) => {
     const classes = useStyles()
 
-    const collectionsToDisplay = collections &&
+    const collectionsToDisplay =
+        collections &&
         collections.content &&
         collections.content.filter(collection => {
             // Don't show chosen Collections from other sections
-            return !(allOtherChosenCollections.find(
-                ({ resourcesId, id: collectionId }) => {
-                    if (resourcesId) {
-                        return resourcesId.find(
-                            ({ id }) =>
-                                id === collection.id ||
-                                currentCollectionIdIfUpdating ===
-                                    collection.id
-                        )
-                    } else {
-                        return collectionId === collection.id
+            return !(
+                allOtherChosenCollections.find(
+                    ({ resourcesId, id: collectionId }) => {
+                        if (resourcesId) {
+                            return resourcesId.find(
+                                ({ id }) =>
+                                    id === collection.id ||
+                                    currentCollectionIdIfUpdating ===
+                                        collection.id
+                            )
+                        } else {
+                            return collectionId === collection.id
+                        }
                     }
-                }
-            //Also don't show the current collection!
-            ) || collection.id === currentCollectionIdIfUpdating)
+                    //Also don't show the current collection!
+                ) || collection.id === currentCollectionIdIfUpdating
+            )
         })
 
-    return collectionsToDisplay &&
-        collectionsToDisplay.length > 0 ? (
+    return collectionsToDisplay && collectionsToDisplay.length > 0 ? (
         <div
             ref={ref => {
                 // console.log(setRef)


### PR DESCRIPTION
There was already a check but it wasn't in all the required clauses.  After putting the id check in the correct place there was an issue where the 'no collections' text wasn't being displayed if a user only has 1 collection (the collection that is being edited).  This is because the collection is correctly removed from the list of collections to display in the modal, but the emptiness check is performed on the full list of collections (ie the list including the single collection that is being edited).

I filter the list of collections before mapping to ui elements, which means we can then check for an empty collection list after the exclusions.